### PR TITLE
Changed Python MySQL package name for the SUSE systems.

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -753,7 +753,7 @@ declare -A pkg_python_mysqldb=(
 	 ['gentoo']="dev-python/mysqlclient"
 	['sabayon']="dev-python/mysqlclient"
 	   ['rhel']="MySQL-python"
-	   ['suse']="python-MySQL-python"
+	   ['suse']="python-PyMySQL"
 	['default']="python-mysql"
 
 	# exceptions


### PR DESCRIPTION
**Problem:**
openSUSE systems can't install netdata using the recommended way: `bash <(curl -Ss https://my-netdata.io/kickstart.sh) all`

That is because the package in place (`python-MySQL-python`) doesn't exist.

**Solution:**
The MySQL Python package is: `python-PyMySQL`.

Reference: https://software.opensuse.org/package/python-PyMySQL