### PR TITLE
Add rhel to warning level for autoconf

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -547,7 +547,8 @@ declare -A pkg_autoconf_archive=(
 	# exceptions
        ['centos-6']="WARNING|"
        ['centos-7']="WARNING|"
-         ['rhel-6']="WARNING|"
+         ['rhel']="WARNING|"
+	 ['rhel-6']="WARNING|"
          ['rhel-7']="WARNING|"
       ['ubuntu-18']="WARNING|"
 	)


### PR DESCRIPTION
My first commit for netdata, so apologies if i'm going about this the wrong way....

We came across an issue today when trying to install netdata. 

In our environment we automate the install of netdata before a test, and then remove again after a test. 

I think that if we try and install autoconf and autoconf_archive at the same time, and this causes us to install autoconf, the script works - if we already have autoconf installed, then the script fails since it is only autoconf_archive which is missing.

i have added RHEL to the list of warning platforms for autoconf_archive

Output from script: 

/etc/os-release information:
NAME            : Amazon Linux AMI
VERSION         : 2018.03
ID              : amzn
ID_LIKE         : rhel fedora
VERSION_ID      : 2018.03

We detected these:
Distribution    : rhel
Version         : 2018.03
Codename        : 2018.03
Package Manager : install_yum
Packages Tree   : rhel
Detection Method: /etc/os-release
Default Python v: 2

So for amazon linux 1, netdata is using rhel, rather than rhel-6 or rhel-7, so to allow install i believe we need rhel in the list of warning platforms, so that the setup will always work.

I am not sure if rhel would automatically cover rhel-6 and rhel-7, and i don't have an environment with those OS installed to test.