### PR TITLE
Fix missing packages bug

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -1315,7 +1315,10 @@ install_emerge() {
 	fi
 
 	# install the required packages
-	run ${sudo} emerge ${opts} -v --noreplace "${@}"
+	for pkg in "${@}"; do
+		[[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
+		run ${sudo} emerge ${opts} -v --noreplace "${pkg}"
+	done
 }
 
 
@@ -1374,7 +1377,10 @@ install_equo() {
 	fi
 
 	# install the required packages
-	run ${sudo} equo i ${opts} "${@}"
+	for pkg in "${@}"; do
+		[[ ${DRYRUN} -eq 0 ]] && echo >&2 "Adding package ${pkg}"
+		run ${sudo} equo i ${opts} "${pkg}"
+	done
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/netdata/netdata/issues/6026

We had an unfortunate event of package manager installation failure, due to missing dependencies.
Our script that does the installation of required packages for netdata, could not successfully add the required packages thus resulting on a failed compilation of netdata because all package transaction was aborted.

To mitigate this, we tested *all* package manager options in the script and we added code to make the installation continue when a single package has a problem. Aggressive approach, but necessary because in some situations some packages *must* be taken care of from the administrators.

For example Judy-devel package in CentOS requires epel-release. Netdata is not authorised to automatically add repositories on a system, so we are obligated to just report the miss and then continue installation successfully. The lack of Judy-devel here would only prevent netdata from using the new Database we are building, so a simple message reporting the miss would be our handling here.

Note: This PR also contains some fixes spotted on the script along the way (described in the commits)