### PR TITLE
netdata/packaging/installer: Finetune required packages

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -589,7 +589,11 @@ declare -A pkg_curl=(
 
 declare -A pkg_tar=(
 	['default']="tar"
-)
+	)
+
+declare -A pkg_grep=(
+	['default']="grep"
+	)
 
 declare -A pkg_git=(
 	 ['gentoo']="dev-vcs/git"
@@ -1062,7 +1066,7 @@ packages() {
 
 	if [ ${PACKAGES_NETDATA} -ne 0 ]
 		then
-	        require_cmd tar          || suitable_package tar
+	        require_cmd tar  || suitable_package tar
 		require_cmd curl || suitable_package curl
 		require_cmd nc   || suitable_package netcat
 	fi
@@ -1648,6 +1652,9 @@ do
 	esac
 	shift
 done
+
+# This is a core requirement, we need grep to detect OS and some distros seem to miss it
+require_cmd grep || suitable_package grep
 
 if [ -z "${package_installer}" -o -z "${tree}" ]
 	then

--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -591,10 +591,6 @@ declare -A pkg_tar=(
 	['default']="tar"
 	)
 
-declare -A pkg_grep=(
-	['default']="grep"
-	)
-
 declare -A pkg_git=(
 	 ['gentoo']="dev-vcs/git"
 	['default']="git"
@@ -1653,8 +1649,10 @@ do
 	shift
 done
 
-# This is a core requirement, we need grep to detect OS and some distros seem to miss it
-require_cmd grep || suitable_package grep
+# Check for missing core commands like grep, warn the user to install it and bail out cleanly
+if ! command -v grep > /dev/null 2>&1; then
+	fatal "'grep' is required for the install to run correctly and was not found on the system. Please install grep and run the installer again."
+fi
 
 if [ -z "${package_installer}" -o -z "${tree}" ]
 	then

--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -1409,11 +1409,18 @@ validate_install_pacman() {
 	# These are not sufficient for netdata install, so we need to make sure that the appropriate libraries are there
 	# by ensuring devel libs are available
 	local x=""
-	if [ "${package}" == "gcc" ]; then
-		x=$(pacman -Qs "${*}" | grep "base-devel")
-	else
-		x=$(pacman -Qs "${*}")
-	fi
+	case "${package}" in
+		"gcc")
+			x=$(pacman -Qs "${*}" | grep "base-devel")
+			;;
+		"tar")
+			x=$(pacman -Qs "${*}" | grep "local/tar")
+			;;
+		*)
+			x=$(pacman -Qs "${*}")
+			;;
+	esac
+
 	[ ! -n "${x}" ] && echo "${*}"
 }
 
@@ -1651,7 +1658,11 @@ done
 
 # Check for missing core commands like grep, warn the user to install it and bail out cleanly
 if ! command -v grep > /dev/null 2>&1; then
-	fatal "'grep' is required for the install to run correctly and was not found on the system. Please install grep and run the installer again."
+	echo >&2
+	echo >&2 "ERROR: 'grep' is required for the install to run correctly and was not found on the system."
+	echo >&2 "Please install grep and run the installer again."
+	echo >&2
+	exit 1
 fi
 
 if [ -z "${package_installer}" -o -z "${tree}" ]

--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -587,6 +587,10 @@ declare -A pkg_curl=(
 	['default']="curl"
 	)
 
+declare -A pkg_tar=(
+	['default']="tar"
+)
+
 declare -A pkg_git=(
 	 ['gentoo']="dev-vcs/git"
 	['default']="git"
@@ -1058,6 +1062,7 @@ packages() {
 
 	if [ ${PACKAGES_NETDATA} -ne 0 ]
 		then
+	        require_cmd tar          || suitable_package tar
 		require_cmd curl || suitable_package curl
 		require_cmd nc   || suitable_package netcat
 	fi


### PR DESCRIPTION
A couple of improvements for the required packages installation script, as seen from testing across distros.

1) make sure you install tar, it is required throughout the install process and not all distributions have it by default aparently
2) When grep is absent inform the user and stop the process

Relates to https://github.com/netdata/netdata/issues/6094