### PR TITLE
netdata/packaging: Secure install on fedora docker 

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -531,6 +531,11 @@ require_cmd() {
 	return 1
 }
 
+declare -A pkg_find=(
+	['fedora']="findutils"
+	['default']="WARNING|"
+)
+
 declare -A pkg_distro_sdk=(
 	 ['alpine']="alpine-sdk"
 	['default']="NOTREQUIRED"
@@ -1026,6 +1031,7 @@ packages() {
 	suitable_package distro-sdk
 
 	require_cmd git          || suitable_package git
+	require_cmd find          || suitable_package find
 
 	require_cmd gcc          || \
 	require_cmd gcc-multilib || suitable_package gcc


### PR DESCRIPTION
fedora distro ditches find command on its docker images, take care of that in case some users run custom installs on fedora docker images