### PR TITLE
netdata/packaging: Handle make detection for pacman (Archlinux)

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -1416,12 +1416,15 @@ validate_install_pacman() {
 	fi;
 	echo >&2 " > Checking if package '${*}' is installed..."
 
-	# Temporary workaround: In archlinux, default installation includes runtime libs under package "gcc"
-	# These are not sufficient for netdata install, so we need to make sure that the appropriate libraries are there
-	# by ensuring devel libs are available
+	# In pacman, you can utilize alternative flags to exactly match package names,
+	# but is highly likely we require pattern matching too in this so we keep -s and match
+	# the exceptional cases like so
 	local x=""
 	case "${package}" in
 		"gcc")
+			# Temporary workaround: In archlinux, default installation includes runtime libs under package "gcc"
+			# These are not sufficient for netdata install, so we need to make sure that the appropriate libraries are there
+			# by ensuring devel libs are available
 			x=$(pacman -Qs "${*}" | grep "base-devel")
 			;;
 		"tar")

--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -1427,6 +1427,9 @@ validate_install_pacman() {
 		"tar")
 			x=$(pacman -Qs "${*}" | grep "local/tar")
 			;;
+		"make")
+			x=$(pacman -Qs "${*}" | grep "local/make ")
+			;;
 		*)
 			x=$(pacman -Qs "${*}")
 			;;


### PR DESCRIPTION
We noticed that our scriptlet does not detect make successfully resulting on failed install.

Kudos to the multi-distro installations on bare OSes that we did on CI, we wouldn't have seen this otherwise not in a million years.