### PR TITLE
netdata/packaging: Update package dependencies

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -555,10 +555,8 @@ declare -A pkg_autoconf_archive=(
 
 	# exceptions
        ['centos-6']="WARNING|"
-       ['centos-7']="WARNING|"
          ['rhel-6']="WARNING|"
          ['rhel-7']="WARNING|"
-      ['ubuntu-18']="WARNING|"
 	)
 
 declare -A pkg_autogen=(

--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -675,7 +675,7 @@ declare -A pkg_libmnl_dev=(
 	 ['gentoo']="net-libs/libmnl"
 	['sabayon']="net-libs/libmnl"
 	   ['rhel']="libmnl-devel"
-	   ['suse']="libmnl0"
+	   ['suse']="libmnl-devel"
 	['default']=""
 	)
 
@@ -903,7 +903,6 @@ declare -A pkg_libuv=(
 	 ['alpine']="libuv-dev"
 	 ['debian']="libuv1-dev"
 	 ['ubuntu']="libuv1-dev"
-	 ['suse']="libuv1"
 	['default']="libuv-devel"
 	)
 


### PR DESCRIPTION
Two set of changes included here:
* As per the repology information and the test we did, autoconf-archive exist on ubuntu18.04, ubuntu18.10 and centos-7
https://repology.org/project/autoconf-archive/versions

* libmnl and libuv had wrong dependencies on