### PR TITLE
Update python package selection for CentOS 8.

### DIFF
--- a/install-required-packages.sh
+++ b/install-required-packages.sh
@@ -761,6 +761,9 @@ declare -A pkg_python=(
 	 ['gentoo']="dev-lang/python"
 	['sabayon']="dev-lang/python:2.7"
 	['default']="python"
+
+	# Exceptions
+       ['centos-8']="python2"
 	)
 
 declare -A pkg_python_mysqldb=(


### PR DESCRIPTION
CentOS 8 switched from a single `python` package to a `python2` and `python36` package, with no backwards compatibility package. This updates the name we use for Python on CentOS 8 to work correctly.

This is a prerequisite for providing packages on CentOS 8.

Note that there are currently still other issues with CentOS 8 right now (namely missing development packages) that preclude Netdata from easily building or installing on it.